### PR TITLE
[Feat] Users Can Specify An Output Location

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ colorbuddy --number-of-colors 5 --output-type original-image.jpg another-image.j
 ## Roadmap
 
 - [x] ~~Allow users to specify multiple images upon which to apply the same options~~
-- [ ] Allow users to specify an output file/directory
+- [ ] Allow users to specify an output file/directory (In Progress)
 - [ ] Allow users to generate a separate standalone palette image
 - [ ] Allow users to generate palette information used by their graphics tools/applications
 - [ ] Add tests


### PR DESCRIPTION
Closes #12

<!-- Provide a general summary of your changes in the Title above -->

## Description

Adds a new option `o`/`output` that allows users to specify a file/directory where output will be created.

## Related issue(s)
<!-- This project only accepts pull requests that are related to open issues -->
<!-- If suggesting a new feature or change, discuss it with maintainers in an issue first -->
<!-- If fixing a bug, there should be an issue describing steps to reproduce -->
<!-- Please link to the issue(s) -->

[Related Issue](https://github.com/adamazing/colorbuddy/issues/12)

## How has this been tested?
<!-- Describe how you tested your changes. If you have added new tests, mention them here. -->
<!-- If you used a particular image for testing, please attach it here hidden beneath a details/summary section -->
This has been tested with a single image as well as passing multiple images:
 - specifying an output file,
 - specifying an output directory,
 - specifying no output.


## Type of change
<!-- The type of change you are making -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] Enhancement (non-breaking change which adds new functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist

- [x] I have read the **CONTRIBUTING** document.
- [x] My PR is based on an existing Issue.
- [x] I have added comments, documentation, and tests where appropriate.
- [x] I have run `cargo fmt`, `cargo clippy`, and `cargo test`.
- [x] I have labelled my PR with either `bug` or `enhancement`.
- [x] I have labelled my PR with `breaking-change` if it alters existing functionality.
