### PR TITLE
[Feat] Add `standalone-palette` output option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,7 +118,7 @@ checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "colorbuddy"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "colorbuddy"
-version = "0.1.5"
+version = "0.1.6"
 authors = ["Adam Henley <adamazing@gmail.com>"]
 edition = "2021"
 description = "Generates a color palette based on an image."

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h1 align="center">🎨 Welcome to Color Buddy 🎨</h1>
-<p>
+<p align="center">
   <img alt="Version" src="https://img.shields.io/badge/version-0.1.4-blue.svg?cacheSeconds=2592000" />
   <a href="#" target="_blank">
     <img alt="License: MIT" src="https://img.shields.io/badge/License-MIT-yellow.svg" />
@@ -53,13 +53,15 @@ Options:
   -o, --output <OUTPUT>
 
   -t, --output-type <OUTPUT_TYPE>
-          [default: original-image] [possible values: json, original-image]
+          [default: original-image] [possible values: json, original-image, standalone-palette]
   -p, --palette-height <PALETTE_HEIGHT>
           [default: 256]
+  -w, --palette-width <PALETTE_WIDTH>
+
   -h, --help
-          Print help
+          Print help information
   -V, --version
-          Print version
+          Print version information
 ```
 
 ## Examples
@@ -83,6 +85,11 @@ colorbuddy --number-of-colors 5 --output-type original-image.jpg another-image.j
 **Specify the height of the palette as a percentage of the original image's height:**
 ```sh
 colorbuddy --palette-height 20% original-image.jpg
+```
+
+**Specify a width, height, and the standalone-palette output height to create a standalone palette image:**
+```sh
+colorbuddy --palette-height 50px --palette-width 500 original-image.jpg
 ```
 
 ## FAQs


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

Closes #13

By specifying `standalone-palette` for the `-t`/`--output-type` option, you can now create a standalone palette image.
When using `standalone-palette` mode you can also specify an absolute pixel value for `-w`/`--palette-width`.

## Related issue(s)
<!-- This project only accepts pull requests that are related to open issues -->
<!-- If suggesting a new feature or change, discuss it with maintainers in an issue first -->
<!-- If fixing a bug, there should be an issue describing steps to reproduce -->
<!-- Please link to the issue(s) -->

[Related Issue](https://github.com/adamazing/colorbuddy/issues/13)

## How has this been tested?

Exhaustive manual testing

## Type of change
<!-- The type of change you are making -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] Enhancement (non-breaking change which adds new functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist

- [x] I have read the **CONTRIBUTING** document.
- [x] My PR is based on an existing Issue.
- [x] I have added comments, documentation, and tests where appropriate.
- [x] I have run `cargo fmt`, `cargo clippy`, and `cargo test`.
- [x] I have labelled my PR with either `bug` or `enhancement`.
- [x] I have labelled my PR with `breaking-change` if it alters existing functionality.
